### PR TITLE
Revamp landing page with dynamic GitHub-powered profile

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,53 +1,265 @@
 <!DOCTYPE html>
-<html>
-
+<html lang="en">
   <head>
-    <meta charset='utf-8'>
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
-    <meta name="description" content="Alistair Walsh : Teaching the world to code">
-
-    <link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">
-
-    <title>Alistair Walsh</title>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Alistair Walsh is a neurofeedback and brain-computer interface researcher, open science educator, and Software Carpentry instructor trainer building tools for creative technology and research communities.">
+    <title>Alistair Walsh | Neurofeedback Researcher &amp; Open Science Educator</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=Space+Grotesk:wght@500;600;700&amp;display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="stylesheets/stylesheet.css">
   </head>
-
   <body>
+    <header class="site-header" id="top">
+      <div class="container header-inner">
+        <a class="site-logo" href="#top" aria-label="Alistair Walsh home">
+          <span aria-hidden="true">AW</span>
+          <span class="sr-only">Alistair Walsh</span>
+        </a>
+        <nav class="primary-nav" aria-label="Primary">
+          <a href="#focus">Focus</a>
+          <a href="#projects">Projects</a>
+          <a href="#timeline">Timeline</a>
+          <a href="#creative">Creative</a>
+          <a href="#contact">Connect</a>
+        </nav>
+        <a class="cta-link" href="https://github.com/alistairwalsh" target="_blank" rel="noopener">GitHub</a>
+      </div>
+    </header>
 
-    <!-- HEADER -->
-    <div id="header_wrap" class="outer">
-        <header class="inner">
-          <a id="forkme_banner" href="https://github.com/alistairwalsh">View on GitHub</a>
-
-          <h1 id="project_title">Alistair Walsh</h1>
-          <h2 id="project_tagline">Teaching the world to code</h2>
-
-        </header>
-    </div>
-
-    <!-- MAIN CONTENT -->
-    <div id="main_content_wrap" class="outer">
-      <section id="main_content" class="inner">
-        <p><img src="https://fbcdn-sphotos-g-a.akamaihd.net/hphotos-ak-xtf1/t31.0-8/p960x960/12841362_10154015601888615_7731016626042483915_o.jpg" alt="" width="300"></p>
-
-<ul>
-<li>BSc. Cognitive Neuroscience (Hon.) Swinburne University of Technology</li>
-<li>Rescom ResearchPlatforms@Unimelb</li>
-<li>Software Carpentry Trainer</li>
-<li><a href="https://github.com/swcarpentry/instructor-training/blob/gh-pages/instructors.md#alistair-walsh">Software Carpentry Instructor Trainer </a></li>
-</ul>
-
-<p>My main area of research is Neuro-feedback and Brain-Computer interfaces. I do hardware, software and analysis of brain activity data. My main programming language is Python, I also use R, C++, Javascript/HTML/CSS</p>
+    <main>
+      <section class="hero" aria-labelledby="hero-title">
+        <div class="container hero-grid">
+          <div class="hero-copy">
+            <p class="eyebrow">Neurofeedback researcher · Open science educator</p>
+            <h1 id="hero-title">Alistair Walsh</h1>
+            <p class="hero-intro">
+              Based in Reservoir, Victoria, Alistair designs neurofeedback and brain-computer interface experiments,
+              builds the tooling that powers them, and teaches researchers how to work confidently with code and data.
+              From Research Platforms at the University of Melbourne to global Software Carpentry cohorts, he helps
+              communities unlock computational thinking while continuing to explore creative technology.
+            </p>
+            <div class="hero-actions">
+              <a class="button primary" href="https://github.com/alistairwalsh" target="_blank" rel="noopener">Explore open-source work</a>
+              <a class="button ghost" href="#contact">Collaborate</a>
+            </div>
+            <dl class="hero-highlights">
+              <div>
+                <dt>Research focus</dt>
+                <dd>Neurofeedback, brain-computer interfaces, data-driven experimentation</dd>
+              </div>
+              <div>
+                <dt>Community roles</dt>
+                <dd>Research Platforms @ University of Melbourne · Software Carpentry Instructor Trainer</dd>
+              </div>
+              <div>
+                <dt>Toolkit</dt>
+                <dd>Python, R, C++, JavaScript, creative audio &amp; hardware integrations</dd>
+              </div>
+            </dl>
+          </div>
+          <figure class="hero-media">
+            <div class="portrait-frame" aria-hidden="true">
+              <img src="https://avatars.githubusercontent.com/u/5056954?v=4" alt="Portrait of Alistair Walsh">
+            </div>
+            <figcaption>Championing accessible coding education since 2013</figcaption>
+          </figure>
+        </div>
       </section>
-    </div>
 
-    <!-- FOOTER  -->
-    <div id="footer_wrap" class="outer">
-      <footer class="inner">
-        <p>Published with <a href="https://pages.github.com">GitHub Pages</a></p>
-      </footer>
-    </div>
+      <section class="stats" aria-labelledby="impact-title">
+        <div class="container">
+          <div class="section-header">
+            <h2 id="impact-title">Impact snapshot</h2>
+            <p>Live metrics pulled from GitHub keep this overview of Alistair's open science footprint up to date.</p>
+          </div>
+          <div class="stats-grid" role="list">
+            <article class="stat-card" role="listitem">
+              <span class="stat-label">Open-source repositories</span>
+              <span class="stat-value" data-stat="repos" aria-live="polite">421</span>
+              <p class="stat-description">A growing archive of research tooling, workshop materials, and creative experiments.</p>
+            </article>
+            <article class="stat-card" role="listitem">
+              <span class="stat-label">Global collaborators</span>
+              <span class="stat-value" data-stat="followers" aria-live="polite">54</span>
+              <p class="stat-description">Researchers and makers following along with neurotech and training initiatives.</p>
+            </article>
+            <article class="stat-card" role="listitem">
+              <span class="stat-label">Community stars</span>
+              <span class="stat-value" data-stat="stars" aria-live="polite">–</span>
+              <p class="stat-description">Total GitHub stars across public repositories, celebrating shared wins.</p>
+            </article>
+            <article class="stat-card" role="listitem">
+              <span class="stat-label">Years building in public</span>
+              <span class="stat-value" data-stat="years" aria-live="polite">12</span>
+              <p class="stat-description">Continuous contributions since joining GitHub in 2013.</p>
+            </article>
+          </div>
+        </div>
+      </section>
 
-    
+      <section class="focus" id="focus" aria-labelledby="focus-title">
+        <div class="container">
+          <div class="section-header">
+            <h2 id="focus-title">What I'm building</h2>
+            <p>Science, software, and storytelling meet across these core themes.</p>
+          </div>
+          <div class="card-grid">
+            <article class="focus-card">
+              <h3>Neurofeedback &amp; BCI research</h3>
+              <p>Designing experiments that close the loop between brain signals and immersive feedback systems. Hands-on with hardware, signal processing pipelines, and rapid prototyping.</p>
+              <ul>
+                <li>Developed <a href="https://github.com/alistairwalsh/Aquire" target="_blank" rel="noopener">Aquire</a>, a Neuroscan Acquire 4.3 client that keeps EEG research flexible.</li>
+                <li>Built <a href="https://github.com/alistairwalsh/countZero" target="_blank" rel="noopener">countZero</a>, a virtual EEG participant for LabStreamingLayer workflows.</li>
+              </ul>
+            </article>
+            <article class="focus-card">
+              <h3>Research platforms &amp; training</h3>
+              <p>Equipping researchers at the University of Melbourne and beyond with the skills to work reproducibly and collaboratively.</p>
+              <ul>
+                <li>Rescom ResearchPlatforms@Unimelb facilitator delivering hands-on data intensives.</li>
+                <li>Created workshop materials spanning Python, SQL, data wrangling, and visualization.</li>
+              </ul>
+            </article>
+            <article class="focus-card">
+              <h3>Global open science community</h3>
+              <p>Mentoring the next generation of instructors and advocating for inclusive, empowering learning spaces.</p>
+              <ul>
+                <li>Software Carpentry Instructor Trainer supporting cohorts across Australasia.</li>
+                <li>Regular contributor to Research Bazaar and allied digital skills programs.</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
 
+      <section class="projects" id="projects" aria-labelledby="projects-title">
+        <div class="container">
+          <div class="section-header">
+            <h2 id="projects-title">Open-source highlights</h2>
+            <p>Recent repositories showcase the blend of research infrastructure, teaching resources, and emerging AI agents.</p>
+          </div>
+          <div class="card-grid" id="project-grid" aria-live="polite">
+            <article class="project-card placeholder">
+              <h3>Loading projects…</h3>
+              <p>This section populates with the latest non-fork repositories from GitHub.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="timeline" id="timeline" aria-labelledby="timeline-title">
+        <div class="container">
+          <div class="section-header">
+            <h2 id="timeline-title">Milestones</h2>
+            <p>Moments that map the journey from neuroscience student to open science leader.</p>
+          </div>
+          <ol class="timeline-list">
+            <li>
+              <div class="timeline-marker" aria-hidden="true"></div>
+              <div class="timeline-content">
+                <time datetime="2013">2013</time>
+                <h3>Launching Aquire for EEG research</h3>
+                <p>Released a Python client for the Neuroscan Acquire 4.3 server, making it easier to stream multi-channel EEG data into neurofeedback environments.</p>
+                <a href="https://github.com/alistairwalsh/Aquire" target="_blank" rel="noopener">Explore Aquire</a>
+              </div>
+            </li>
+            <li>
+              <div class="timeline-marker" aria-hidden="true"></div>
+              <div class="timeline-content">
+                <time datetime="2013">2013</time>
+                <h3>Simulating participants with countZero</h3>
+                <p>Created a LabStreamingLayer-ready virtual participant to stress-test neurotechnology pipelines before moving to the lab.</p>
+                <a href="https://github.com/alistairwalsh/countZero" target="_blank" rel="noopener">See countZero</a>
+              </div>
+            </li>
+            <li>
+              <div class="timeline-marker" aria-hidden="true"></div>
+              <div class="timeline-content">
+                <time datetime="2015">2015</time>
+                <h3>Scaling Python training across campuses</h3>
+                <p>Led Software Carpentry workshops at Swinburne University of Technology and the University of Melbourne, expanding the reach of hands-on coding education.</p>
+                <a href="https://github.com/alistairwalsh/2015-05-04-swinpython" target="_blank" rel="noopener">Swinburne workshop</a>
+                <a href="https://github.com/alistairwalsh/2015-05-25-unimelb" target="_blank" rel="noopener">Unimelb workshop</a>
+              </div>
+            </li>
+            <li>
+              <div class="timeline-marker" aria-hidden="true"></div>
+              <div class="timeline-content">
+                <time datetime="2019">2019</time>
+                <h3>Designing modular course starters</h3>
+                <p>Published a reusable template for interactive Python courses, streamlining delivery for Research Bazaar and partner events.</p>
+                <a href="https://github.com/alistairwalsh/course-starter-python" target="_blank" rel="noopener">Course starter</a>
+              </div>
+            </li>
+            <li>
+              <div class="timeline-marker" aria-hidden="true"></div>
+              <div class="timeline-content">
+                <time datetime="2025">2025</time>
+                <h3>Building library-friendly AI agents</h3>
+                <p>Most recently, launched <a href="https://github.com/alistairwalsh/agex" target="_blank" rel="noopener">agex</a>, experimenting with approachable agentic workflows for collections and cultural institutions.</p>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </section>
+
+      <section class="creative" id="creative" aria-labelledby="creative-title">
+        <div class="container">
+          <div class="section-header">
+            <h2 id="creative-title">Creative &amp; experimental labs</h2>
+            <p>Explorations in audio, generative media, and storytelling tools that complement scientific practice.</p>
+          </div>
+          <div class="card-grid" id="creative-grid" aria-live="polite">
+            <article class="project-card placeholder">
+              <h3>Loading creative experiments…</h3>
+              <p>Keep an eye out for generative audio and storytelling projects as they sync from GitHub.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="toolbox" aria-labelledby="toolbox-title">
+        <div class="container">
+          <div class="section-header">
+            <h2 id="toolbox-title">Research tooling &amp; writing</h2>
+            <p>Small but mighty scripts, notes, and posts that smooth research workflows.</p>
+          </div>
+          <div class="tool-list" id="tool-list" aria-live="polite">
+            <article class="tool-card placeholder">
+              <h3>Loading highlights…</h3>
+              <p>Highlights from gists and the archive will appear here shortly.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="callout" id="contact" aria-labelledby="contact-title">
+        <div class="container callout-inner">
+          <div class="callout-text">
+            <h2 id="contact-title">Let's collaborate</h2>
+            <p>
+              Whether you're exploring neurofeedback, planning a Research Bazaar sprint, or dreaming up a creative technology installation,
+              reach out to co-design the next experiment.
+            </p>
+          </div>
+          <div class="callout-actions">
+            <a class="button primary" href="https://github.com/alistairwalsh" target="_blank" rel="noopener">Message on GitHub</a>
+            <a class="button ghost" href="https://github.com/alistairwalsh/alistairwalsh.github.io/issues/new" target="_blank" rel="noopener">Start a conversation</a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer-inner">
+        <p>© <span id="footer-year"></span> Alistair Walsh. Published with <a href="https://pages.github.com" target="_blank" rel="noopener">GitHub Pages</a>.</p>
+        <a class="back-to-top" href="#top">Back to top</a>
+      </div>
+    </footer>
+
+    <script src="javascripts/main.js" defer></script>
   </body>
 </html>

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -1,1 +1,260 @@
-console.log('This would be the main JS file.');
+const username = 'alistairwalsh';
+const selectors = {
+  repos: document.querySelector('[data-stat="repos"]'),
+  followers: document.querySelector('[data-stat="followers"]'),
+  stars: document.querySelector('[data-stat="stars"]'),
+  years: document.querySelector('[data-stat="years"]'),
+};
+const projectGrid = document.getElementById('project-grid');
+const creativeGrid = document.getElementById('creative-grid');
+const toolList = document.getElementById('tool-list');
+const footerYear = document.getElementById('footer-year');
+
+const formatNumber = (value) => {
+  if (typeof value !== 'number') return '–';
+  return value.toLocaleString();
+};
+
+const createMetaIcon = (path) => {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('aria-hidden', 'true');
+  svg.innerHTML = `<path d="${path}"/>`;
+  return svg;
+};
+
+const starPath = 'M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z';
+const clockPath = 'M12 2a10 10 0 1 0 10 10A10.011 10.011 0 0 0 12 2zm0 18a8 8 0 1 1 8-8 8.009 8.009 0 0 1-8 8zm.5-13h-1v6l5.25 3.15.5-.84-4.75-2.81z';
+
+const clearNode = (node) => {
+  if (!node) return;
+  while (node.firstChild) {
+    node.removeChild(node.firstChild);
+  }
+};
+
+const createBadge = (text, variant = 'default') => {
+  const span = document.createElement('span');
+  span.className = `badge badge-${variant}`;
+  span.textContent = text;
+  return span;
+};
+
+const createProjectCard = (repo, { highlightFork = false } = {}) => {
+  const article = document.createElement('article');
+  article.className = 'project-card';
+
+  const title = document.createElement('h3');
+  title.textContent = repo.name.replace(/[-_]/g, ' ');
+  article.appendChild(title);
+
+  if (highlightFork && repo.fork) {
+    article.appendChild(createBadge('Forked exploration', 'outline'));
+  } else if (!repo.fork) {
+    article.appendChild(createBadge('Original build', 'solid'));
+  }
+
+  const description = document.createElement('p');
+  description.textContent = repo.description || 'No description added yet—discover the code on GitHub.';
+  article.appendChild(description);
+
+  const meta = document.createElement('div');
+  meta.className = 'project-meta';
+
+  const star = document.createElement('span');
+  star.appendChild(createMetaIcon(starPath));
+  star.appendChild(document.createTextNode(formatNumber(repo.stargazers_count)));
+  meta.appendChild(star);
+
+  if (repo.language) {
+    const lang = document.createElement('span');
+    lang.textContent = repo.language;
+    meta.appendChild(lang);
+  }
+
+  if (repo.pushed_at) {
+    const updated = document.createElement('span');
+    updated.appendChild(createMetaIcon(clockPath));
+    const date = new Date(repo.pushed_at);
+    updated.appendChild(document.createTextNode(date.toLocaleDateString(undefined, { month: 'short', year: 'numeric' })));
+    meta.appendChild(updated);
+  }
+
+  article.appendChild(meta);
+
+  const link = document.createElement('a');
+  link.href = repo.html_url;
+  link.target = '_blank';
+  link.rel = 'noopener';
+  link.className = 'button ghost';
+  link.textContent = 'View on GitHub';
+  article.appendChild(link);
+
+  return article;
+};
+
+const createToolCard = (item) => {
+  const article = document.createElement('article');
+  article.className = 'tool-card';
+
+  if (item.created_at) {
+    const time = document.createElement('time');
+    time.dateTime = item.created_at;
+    time.textContent = new Date(item.created_at).getFullYear();
+    article.appendChild(time);
+  }
+
+  const title = document.createElement('h3');
+  title.textContent = item.description || 'Untitled resource';
+  article.appendChild(title);
+
+  const link = document.createElement('a');
+  link.href = item.html_url;
+  link.target = '_blank';
+  link.rel = 'noopener';
+  link.textContent = 'Open on GitHub';
+  article.appendChild(link);
+
+  return article;
+};
+
+const setStats = (user, repos) => {
+  if (!user) return;
+  if (selectors.repos) selectors.repos.textContent = formatNumber(user.public_repos);
+  if (selectors.followers) selectors.followers.textContent = formatNumber(user.followers);
+  if (selectors.years) {
+    const accountAge = Math.max(1, new Date().getFullYear() - new Date(user.created_at).getFullYear());
+    selectors.years.textContent = formatNumber(accountAge);
+  }
+  if (selectors.stars && Array.isArray(repos)) {
+    const totalStars = repos.reduce((sum, repo) => sum + (repo.stargazers_count || 0), 0);
+    selectors.stars.textContent = formatNumber(totalStars);
+  }
+};
+
+const renderProjects = (repos) => {
+  if (!projectGrid) return;
+  clearNode(projectGrid);
+  if (!Array.isArray(repos)) {
+    projectGrid.appendChild(createFallbackCard('Unable to load projects right now.'));
+    return;
+  }
+
+  const curated = repos
+    .filter((repo) => !repo.fork)
+    .sort((a, b) => {
+      if (b.stargazers_count === a.stargazers_count) {
+        return new Date(b.pushed_at) - new Date(a.pushed_at);
+      }
+      return b.stargazers_count - a.stargazers_count;
+    })
+    .slice(0, 4);
+
+  if (curated.length === 0) {
+    projectGrid.appendChild(createFallbackCard('No public projects found yet—check back soon.'));
+    return;
+  }
+
+  curated.forEach((repo) => projectGrid.appendChild(createProjectCard(repo)));
+};
+
+const renderCreative = (repos) => {
+  if (!creativeGrid) return;
+  clearNode(creativeGrid);
+  if (!Array.isArray(repos)) {
+    creativeGrid.appendChild(createFallbackCard('Unable to load creative experiments at the moment.'));
+    return;
+  }
+
+  const creativeRepos = repos
+    .filter((repo) => /(audio|music|sound|story|creative)/i.test(`${repo.name} ${repo.description || ''}`))
+    .sort((a, b) => new Date(b.pushed_at) - new Date(a.pushed_at))
+    .slice(0, 4);
+
+  if (creativeRepos.length === 0) {
+    creativeGrid.appendChild(createFallbackCard('Creative experiments will appear here as they are published.'));
+    return;
+  }
+
+  creativeRepos.forEach((repo) => creativeGrid.appendChild(createProjectCard(repo, { highlightFork: true })));
+};
+
+const renderTools = (gists) => {
+  if (!toolList) return;
+  clearNode(toolList);
+  if (!Array.isArray(gists)) {
+    toolList.appendChild(createFallbackCard('Unable to load research tooling right now.'));
+    return;
+  }
+
+  const curated = gists
+    .filter((gist) => gist.description && gist.description.trim().length > 0)
+    .slice(0, 3);
+
+  if (curated.length === 0) {
+    toolList.appendChild(createFallbackCard('Add a description to a gist to feature it here.'));
+    return;
+  }
+
+  curated.forEach((gist) => toolList.appendChild(createToolCard(gist)));
+};
+
+const createFallbackCard = (message) => {
+  const article = document.createElement('article');
+  article.className = 'project-card placeholder';
+  const heading = document.createElement('h3');
+  heading.textContent = message;
+  article.appendChild(heading);
+  return article;
+};
+
+const fetchJSON = async (url) => {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Request failed: ${response.status}`);
+  }
+  return response.json();
+};
+
+const initialise = async () => {
+  if (footerYear) {
+    footerYear.textContent = new Date().getFullYear();
+  }
+
+  try {
+    const userPromise = fetchJSON(`https://api.github.com/users/${username}`);
+    const repoPromise = fetchJSON(`https://api.github.com/users/${username}/repos?per_page=100&sort=updated`);
+    const gistPromise = fetchJSON(`https://api.github.com/users/${username}/gists?per_page=5`);
+
+    const [user, repos, gists] = await Promise.allSettled([userPromise, repoPromise, gistPromise]);
+
+    if (user.status === 'fulfilled' && repos.status === 'fulfilled') {
+      setStats(user.value, repos.value);
+      renderProjects(repos.value);
+      renderCreative(repos.value);
+    } else {
+      if (user.status === 'fulfilled') {
+        setStats(user.value);
+      }
+      if (repos.status !== 'fulfilled') {
+        renderProjects(null);
+        renderCreative(null);
+        console.error('Failed to load repositories', repos.reason);
+      }
+    }
+
+    if (gists.status === 'fulfilled') {
+      renderTools(gists.value);
+    } else {
+      renderTools(null);
+      console.error('Failed to load gists', gists.reason);
+    }
+  } catch (error) {
+    console.error('Unexpected error initialising page', error);
+    renderProjects(null);
+    renderCreative(null);
+    renderTools(null);
+  }
+};
+
+document.addEventListener('DOMContentLoaded', initialise);

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -1,425 +1,638 @@
-/*******************************************************************************
-Slate Theme for GitHub Pages
-by Jason Costello, @jsncostello
-*******************************************************************************/
-
-@import url(github-light.css);
-
-/*******************************************************************************
-MeyerWeb Reset
-*******************************************************************************/
-
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font: inherit;
-  vertical-align: baseline;
+:root {
+  --bg: #05060a;
+  --bg-alt: #0f111b;
+  --accent: #6cf0c2;
+  --accent-strong: #39c1ff;
+  --text: #f8f9fb;
+  --muted: rgba(248, 249, 251, 0.7);
+  --surface: rgba(15, 17, 27, 0.72);
+  --surface-border: rgba(108, 240, 194, 0.25);
+  --surface-alt: rgba(12, 14, 22, 0.88);
+  --gradient: radial-gradient(circle at top left, rgba(108, 240, 194, 0.2), transparent 55%),
+    radial-gradient(circle at top right, rgba(57, 193, 255, 0.2), transparent 50%),
+    linear-gradient(160deg, rgba(12, 14, 22, 0.95) 0%, rgba(5, 6, 10, 0.95) 70%);
+  --radius-lg: 32px;
+  --radius-md: 20px;
+  --radius-sm: 12px;
+  --transition: 200ms ease;
+  color-scheme: dark;
 }
 
-/* HTML5 display-role reset for older browsers */
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-  display: block;
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
-ol, ul {
-  list-style: none;
+html {
+  scroll-behavior: smooth;
 }
-
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
-}
-
-/*******************************************************************************
-Theme Styles
-*******************************************************************************/
 
 body {
-  box-sizing: border-box;
-  color:#373737;
-  background: #212121;
-  font-size: 16px;
-  font-family: 'Myriad Pro', Calibri, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  -webkit-font-smoothing: antialiased;
-}
-
-h1, h2, h3, h4, h5, h6 {
-  margin: 10px 0;
-  font-weight: 700;
-  color:#222222;
-  font-family: 'Lucida Grande', 'Calibri', Helvetica, Arial, sans-serif;
-  letter-spacing: -1px;
-}
-
-h1 {
-  font-size: 36px;
-  font-weight: 700;
-}
-
-h2 {
-  padding-bottom: 10px;
-  font-size: 32px;
-  background: url('../images/bg_hr.png') repeat-x bottom;
-}
-
-h3 {
-  font-size: 24px;
-}
-
-h4 {
-  font-size: 21px;
-}
-
-h5 {
-  font-size: 18px;
-}
-
-h6 {
-  font-size: 16px;
-}
-
-p {
-  margin: 10px 0 15px 0;
-}
-
-footer p {
-  color: #f2f2f2;
-}
-
-a {
-  text-decoration: none;
-  color: #007edf;
-  text-shadow: none;
-
-  transition: color 0.5s ease;
-  transition: text-shadow 0.5s ease;
-  -webkit-transition: color 0.5s ease;
-  -webkit-transition: text-shadow 0.5s ease;
-  -moz-transition: color 0.5s ease;
-  -moz-transition: text-shadow 0.5s ease;
-  -o-transition: color 0.5s ease;
-  -o-transition: text-shadow 0.5s ease;
-  -ms-transition: color 0.5s ease;
-  -ms-transition: text-shadow 0.5s ease;
-}
-
-a:hover, a:focus {text-decoration: underline;}
-
-footer a {
-  color: #F2F2F2;
-  text-decoration: underline;
-}
-
-em {
-  font-style: italic;
-}
-
-strong {
-  font-weight: bold;
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: var(--gradient);
+  color: var(--text);
+  line-height: 1.6;
+  letter-spacing: 0.01em;
 }
 
 img {
-  position: relative;
-  margin: 0 auto;
-  max-width: 739px;
-  padding: 5px;
-  margin: 10px 0 10px 0;
-  border: 1px solid #ebebeb;
-
-  box-shadow: 0 0 5px #ebebeb;
-  -webkit-box-shadow: 0 0 5px #ebebeb;
-  -moz-box-shadow: 0 0 5px #ebebeb;
-  -o-box-shadow: 0 0 5px #ebebeb;
-  -ms-box-shadow: 0 0 5px #ebebeb;
+  max-width: 100%;
+  display: block;
 }
 
-p img {
-  display: inline;
+a {
+  color: var(--accent);
+  text-decoration: none;
+  transition: color var(--transition), text-shadow var(--transition);
+}
+
+a:hover,
+a:focus {
+  color: var(--accent-strong);
+  text-shadow: 0 0 16px rgba(108, 240, 194, 0.45);
+}
+
+a.button,
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.75rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  transition: transform var(--transition), box-shadow var(--transition), background-color var(--transition);
+}
+
+.button.primary {
+  background: linear-gradient(120deg, rgba(108, 240, 194, 0.9), rgba(57, 193, 255, 0.9));
+  color: #041017;
+  box-shadow: 0 18px 40px -20px rgba(57, 193, 255, 0.8);
+}
+
+.button.primary:hover,
+.button.primary:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 50px -20px rgba(108, 240, 194, 0.9);
+}
+
+.button.ghost {
+  border-color: rgba(108, 240, 194, 0.4);
+  color: var(--text);
+  background: rgba(12, 14, 22, 0.45);
+}
+
+.button.ghost:hover,
+.button.ghost:focus {
+  border-color: rgba(57, 193, 255, 0.6);
+  transform: translateY(-2px);
+}
+
+.container {
+  width: min(1120px, 90vw);
+  margin: 0 auto;
+  position: relative;
+  z-index: 2;
+}
+
+.section-header {
+  margin-bottom: 2rem;
+}
+
+.section-header h2 {
+  font-family: 'Space Grotesk', 'Inter', sans-serif;
+  font-size: clamp(2rem, 1.7rem + 1vw, 2.6rem);
+  margin: 0 0 0.6rem;
+}
+
+.section-header p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(5, 6, 10, 0.9);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(108, 240, 194, 0.12);
+}
+
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0;
+}
+
+.site-logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  border: 1px solid rgba(108, 240, 194, 0.4);
+  color: var(--accent);
+  background: rgba(12, 14, 22, 0.7);
+}
+
+.primary-nav {
+  display: flex;
+  gap: 1.4rem;
+  font-weight: 500;
+}
+
+.primary-nav a {
+  position: relative;
+  padding-bottom: 0.3rem;
+}
+
+.primary-nav a::after {
+  content: '';
+  position: absolute;
+  inset: auto 0 -0.4rem;
+  height: 2px;
+  background: linear-gradient(120deg, rgba(108, 240, 194, 0.8), rgba(57, 193, 255, 0.8));
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--transition);
+}
+
+.primary-nav a:hover::after,
+.primary-nav a:focus::after {
+  transform: scaleX(1);
+}
+
+.cta-link {
+  font-weight: 600;
+  color: var(--accent);
+  border: 1px solid rgba(108, 240, 194, 0.4);
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  background: rgba(5, 6, 10, 0.6);
+}
+
+.cta-link:hover,
+.cta-link:focus {
+  border-color: rgba(57, 193, 255, 0.7);
+  color: var(--accent-strong);
+}
+
+.hero {
+  padding: 6rem 0 4rem;
+}
+
+.hero-grid {
+  display: grid;
+  gap: 3rem;
+  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.eyebrow {
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: rgba(108, 240, 194, 0.8);
+  margin: 0 0 1rem;
+}
+
+.hero h1 {
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: clamp(2.8rem, 2.2rem + 2vw, 3.8rem);
+  line-height: 1.1;
+  margin: 0 0 1rem;
+}
+
+.hero-intro {
+  margin: 0 0 1.6rem;
+  color: var(--muted);
+  font-size: 1.05rem;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.hero-highlights {
+  display: grid;
+  gap: 1rem;
+  margin: 0;
+}
+
+.hero-highlights div {
+  padding: 1rem 1.2rem;
+  border-radius: var(--radius-sm);
+  background: rgba(12, 14, 22, 0.65);
+  border: 1px solid rgba(108, 240, 194, 0.18);
+}
+
+.hero-highlights dt {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.75rem;
+  color: rgba(108, 240, 194, 0.85);
+  margin-bottom: 0.45rem;
+}
+
+.hero-highlights dd {
+  margin: 0;
+  color: var(--muted);
+}
+
+.hero-media {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.portrait-frame {
+  border-radius: 30px;
+  overflow: hidden;
+  padding: 0.7rem;
+  background: linear-gradient(135deg, rgba(108, 240, 194, 0.35), rgba(57, 193, 255, 0.35));
+  box-shadow: 0 30px 60px -40px rgba(57, 193, 255, 0.9);
+}
+
+.portrait-frame img {
+  border-radius: 24px;
+}
+
+.hero-media figcaption {
+  color: rgba(248, 249, 251, 0.6);
+  font-size: 0.9rem;
+}
+
+.stats,
+.focus,
+.projects,
+.timeline,
+.creative,
+.toolbox,
+.callout {
+  padding: 4rem 0;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.stat-card {
+  padding: 2rem 1.6rem;
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  position: relative;
+  overflow: hidden;
+}
+
+.stat-card::after {
+  content: '';
+  position: absolute;
+  inset: auto -20% -55% 60%;
+  height: 180px;
+  filter: blur(60px);
+  background: radial-gradient(circle, rgba(108, 240, 194, 0.25), transparent 70%);
+  pointer-events: none;
+}
+
+.stat-label {
+  display: block;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.75rem;
+  color: rgba(248, 249, 251, 0.6);
+  margin-bottom: 0.6rem;
+}
+
+.stat-value {
+  display: block;
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: clamp(2.3rem, 1.9rem + 1vw, 2.9rem);
+  margin-bottom: 0.5rem;
+}
+
+.stat-description {
+  margin: 0;
+  color: var(--muted);
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.7rem;
+}
+
+.focus-card,
+.project-card,
+.tool-card {
+  padding: 2rem 1.75rem;
+  border-radius: var(--radius-md);
+  background: var(--surface-alt);
+  border: 1px solid rgba(108, 240, 194, 0.18);
+  box-shadow: 0 30px 60px -50px rgba(12, 173, 255, 0.7);
+  transition: transform var(--transition), border-color var(--transition);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 600;
+  width: fit-content;
+  border: 1px solid rgba(108, 240, 194, 0.35);
+  background: rgba(108, 240, 194, 0.12);
+  color: rgba(108, 240, 194, 0.88);
+}
+
+.badge-solid {
+  border-color: transparent;
+  background: linear-gradient(120deg, rgba(108, 240, 194, 0.9), rgba(57, 193, 255, 0.9));
+  color: #041017;
+}
+
+.badge-outline {
+  border-color: rgba(108, 240, 194, 0.45);
+  background: rgba(12, 14, 22, 0.6);
+}
+
+.focus-card:hover,
+.focus-card:focus-within,
+.project-card:hover,
+.project-card:focus-within,
+.tool-card:hover,
+.tool-card:focus-within {
+  transform: translateY(-4px);
+  border-color: rgba(108, 240, 194, 0.5);
+}
+
+.focus-card h3,
+.project-card h3,
+.tool-card h3 {
+  font-family: 'Space Grotesk', sans-serif;
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.focus-card p,
+.project-card p,
+.tool-card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.focus-card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: rgba(248, 249, 251, 0.75);
+  display: grid;
+  gap: 0.65rem;
+}
+
+.focus-card li::marker {
+  color: rgba(108, 240, 194, 0.8);
+}
+
+.project-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  font-size: 0.85rem;
+  color: rgba(248, 249, 251, 0.6);
+}
+
+.project-meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.project-meta svg {
+  width: 16px;
+  height: 16px;
+  fill: currentColor;
+}
+
+.timeline-list {
+  list-style: none;
   margin: 0;
   padding: 0;
-  vertical-align: middle;
-  text-align: center;
-  border: none;
-}
-
-pre, code {
-  width: 100%;
-  color: #222;
-  background-color: #fff;
-
-  font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
-  font-size: 14px;
-
-  border-radius: 2px;
-  -moz-border-radius: 2px;
-  -webkit-border-radius: 2px;
-}
-
-pre {
-  width: 100%;
-  padding: 10px;
-  box-shadow: 0 0 10px rgba(0,0,0,.1);
-  overflow: auto;
-}
-
-code {
-  padding: 3px;
-  margin: 0 3px;
-  box-shadow: 0 0 10px rgba(0,0,0,.1);
-}
-
-pre code {
-  display: block;
-  box-shadow: none;
-}
-
-blockquote {
-  color: #666;
-  margin-bottom: 20px;
-  padding: 0 0 0 20px;
-  border-left: 3px solid #bbb;
-}
-
-
-ul, ol, dl {
-  margin-bottom: 15px
-}
-
-ul {
-  list-style-position: inside;
-  list-style: disc;
-  padding-left: 20px;
-}
-
-ol {
-  list-style-position: inside;
-  list-style: decimal;
-  padding-left: 20px;
-}
-
-dl dt {
-  font-weight: bold;
-}
-
-dl dd {
-  padding-left: 20px;
-  font-style: italic;
-}
-
-dl p {
-  padding-left: 20px;
-  font-style: italic;
-}
-
-hr {
-  height: 1px;
-  margin-bottom: 5px;
-  border: none;
-  background: url('../images/bg_hr.png') repeat-x center;
-}
-
-table {
-  border: 1px solid #373737;
-  margin-bottom: 20px;
-  text-align: left;
- }
-
-th {
-  font-family: 'Lucida Grande', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  padding: 10px;
-  background: #373737;
-  color: #fff;
- }
-
-td {
-  padding: 10px;
-  border: 1px solid #373737;
- }
-
-form {
-  background: #f2f2f2;
-  padding: 20px;
-}
-
-/*******************************************************************************
-Full-Width Styles
-*******************************************************************************/
-
-.outer {
-  width: 100%;
-}
-
-.inner {
   position: relative;
-  max-width: 640px;
-  padding: 20px 10px;
-  margin: 0 auto;
 }
 
-#forkme_banner {
-  display: block;
+.timeline-list::before {
+  content: '';
   position: absolute;
-  top:0;
-  right: 10px;
-  z-index: 10;
-  padding: 10px 50px 10px 10px;
-  color: #fff;
-  background: url('../images/blacktocat.png') #0090ff no-repeat 95% 50%;
-  font-weight: 700;
-  box-shadow: 0 0 10px rgba(0,0,0,.5);
-  border-bottom-left-radius: 2px;
-  border-bottom-right-radius: 2px;
+  top: 0.5rem;
+  left: 12px;
+  bottom: 0.5rem;
+  width: 2px;
+  background: linear-gradient(to bottom, rgba(108, 240, 194, 0.5), rgba(57, 193, 255, 0.1));
 }
 
-#header_wrap {
-  background: #212121;
-  background: -moz-linear-gradient(top, #373737, #212121);
-  background: -webkit-linear-gradient(top, #373737, #212121);
-  background: -ms-linear-gradient(top, #373737, #212121);
-  background: -o-linear-gradient(top, #373737, #212121);
-  background: linear-gradient(top, #373737, #212121);
+.timeline-list li {
+  position: relative;
+  padding-left: 3.5rem;
+  margin-bottom: 2.5rem;
 }
 
-#header_wrap .inner {
-  padding: 50px 10px 30px 10px;
+.timeline-marker {
+  position: absolute;
+  left: 4px;
+  top: 0.6rem;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(108, 240, 194, 0.9), rgba(57, 193, 255, 0.9));
+  box-shadow: 0 0 0 6px rgba(108, 240, 194, 0.15);
 }
 
-#project_title {
+.timeline-content {
+  background: var(--surface-alt);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(108, 240, 194, 0.18);
+  padding: 1.6rem 1.5rem;
+  display: grid;
+  gap: 0.7rem;
+}
+
+.timeline-content time {
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: rgba(108, 240, 194, 0.8);
+}
+
+.timeline-content h3 {
+  font-family: 'Space Grotesk', sans-serif;
   margin: 0;
-  color: #fff;
-  font-size: 42px;
-  font-weight: 700;
-  text-shadow: #111 0px 0px 10px;
+  font-size: 1.35rem;
 }
 
-#project_tagline {
-  color: #fff;
-  font-size: 24px;
-  font-weight: 300;
-  background: none;
-  text-shadow: #111 0px 0px 10px;
+.timeline-content a {
+  font-weight: 500;
 }
 
-#downloads {
+.tool-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.tool-card time {
+  font-size: 0.8rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(108, 240, 194, 0.7);
+}
+
+.callout {
+  padding: 4rem 0 5rem;
+}
+
+.callout-inner {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+  gap: 2rem;
+  background: linear-gradient(120deg, rgba(108, 240, 194, 0.2), rgba(57, 193, 255, 0.25));
+  border-radius: var(--radius-lg);
+  padding: 2.5rem;
+  border: 1px solid rgba(108, 240, 194, 0.32);
+}
+
+.callout-text h2 {
+  font-family: 'Space Grotesk', sans-serif;
+  margin: 0 0 0.8rem;
+  font-size: clamp(2rem, 1.6rem + 1vw, 2.6rem);
+}
+
+.callout-text p {
+  margin: 0;
+  color: rgba(5, 6, 10, 0.85);
+  font-weight: 500;
+}
+
+.callout-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: flex-start;
+}
+
+.site-footer {
+  padding: 2rem 0;
+  border-top: 1px solid rgba(108, 240, 194, 0.16);
+  background: rgba(5, 6, 10, 0.92);
+}
+
+.footer-inner {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.95rem;
+  color: rgba(248, 249, 251, 0.65);
+}
+
+.back-to-top {
+  font-weight: 600;
+}
+
+.placeholder {
+  text-align: center;
+  align-items: center;
+  justify-content: center;
+  min-height: 160px;
+}
+
+.sr-only {
   position: absolute;
-  width: 210px;
-  z-index: 10;
-  bottom: -40px;
-  right: 0;
-  height: 70px;
-  background: url('../images/icon_download.png') no-repeat 0% 90%;
-}
-
-.zip_download_link {
-  display: block;
-  float: right;
-  width: 90px;
-  height:70px;
-  text-indent: -5000px;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
   overflow: hidden;
-  background: url(../images/sprite_download.png) no-repeat bottom left;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
-.tar_download_link {
-  display: block;
-  float: right;
-  width: 90px;
-  height:70px;
-  text-indent: -5000px;
-  overflow: hidden;
-  background: url(../images/sprite_download.png) no-repeat bottom right;
-  margin-left: 10px;
-}
-
-.zip_download_link:hover {
-  background: url(../images/sprite_download.png) no-repeat top left;
-}
-
-.tar_download_link:hover {
-  background: url(../images/sprite_download.png) no-repeat top right;
-}
-
-#main_content_wrap {
-  background: #f2f2f2;
-  border-top: 1px solid #111;
-  border-bottom: 1px solid #111;
-}
-
-#main_content {
-  padding-top: 40px;
-}
-
-#footer_wrap {
-  background: #212121;
-}
-
-
-
-/*******************************************************************************
-Small Device Styles
-*******************************************************************************/
-
-@media screen and (max-width: 480px) {
-  body {
-    font-size:14px;
-  }
-
-  #downloads {
+@media (max-width: 960px) {
+  .primary-nav {
     display: none;
   }
 
-  .inner {
-    min-width: 320px;
-    max-width: 480px;
+  .hero {
+    padding-top: 5rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .hero-actions {
+    justify-content: flex-start;
   }
 
-  #project_title {
-  font-size: 32px;
+  .timeline-list li {
+    padding-left: 2.8rem;
   }
 
-  h1 {
-    font-size: 28px;
+  .callout-inner {
+    padding: 2.2rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .header-inner {
+    gap: 1rem;
   }
 
-  h2 {
-    font-size: 24px;
+  .cta-link {
+    padding: 0.5rem 0.9rem;
   }
 
-  h3 {
-    font-size: 21px;
+  .hero-highlights div {
+    padding: 0.8rem 1rem;
   }
 
-  h4 {
-    font-size: 18px;
+  .card-grid,
+  .tool-list {
+    grid-template-columns: 1fr;
   }
+}
 
-  h5 {
-    font-size: 14px;
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+    scroll-behavior: auto !important;
   }
-
-  h6 {
-    font-size: 12px;
-  }
-
-  code, pre {
-    min-width: 320px;
-    max-width: 480px;
-    font-size: 11px;
-  }
-
 }


### PR DESCRIPTION
## Summary
- rebuild the landing page with a new hero, focus, timeline, creative, and contact sections tailored to neurofeedback and open science work
- overhaul the global stylesheet with a dark, gradient-driven theme and reusable card, badge, and layout utilities
- replace the placeholder JavaScript with logic that pulls live GitHub stats, repositories, and gists to populate the page dynamically

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d0d7c04d3083228eef2da5dcc81ac0