### PR TITLE
Refresh homepage to highlight generative AI consulting services

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Alistair Walsh is a neurofeedback and brain-computer interface researcher, open science educator, and Software Carpentry instructor trainer building tools for creative technology and research communities.">
-    <title>Alistair Walsh | Neurofeedback Researcher &amp; Open Science Educator</title>
+    <meta name="description" content="Alistair Walsh is a generative AI consultant and neurotechnology researcher helping organisations design ethical AI strategies, build agentic workflows, and upskill teams with open science practices.">
+    <title>Alistair Walsh | Generative AI Consultant &amp; Open Science Leader</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=Space+Grotesk:wght@500;600;700&amp;display=swap" rel="stylesheet">
@@ -19,7 +19,9 @@
           <span class="sr-only">Alistair Walsh</span>
         </a>
         <nav class="primary-nav" aria-label="Primary">
-          <a href="#focus">Focus</a>
+          <a href="#focus">Pillars</a>
+          <a href="#services">Services</a>
+          <a href="#approach">Approach</a>
           <a href="#projects">Projects</a>
           <a href="#timeline">Timeline</a>
           <a href="#creative">Creative</a>
@@ -33,22 +35,23 @@
       <section class="hero" aria-labelledby="hero-title">
         <div class="container hero-grid">
           <div class="hero-copy">
-            <p class="eyebrow">Neurofeedback researcher · Open science educator</p>
+            <p class="eyebrow">Generative AI consultant · Neurotech researcher</p>
             <h1 id="hero-title">Alistair Walsh</h1>
             <p class="hero-intro">
-              Based in Reservoir, Victoria, Alistair designs neurofeedback and brain-computer interface experiments,
-              builds the tooling that powers them, and teaches researchers how to work confidently with code and data.
-              From Research Platforms at the University of Melbourne to global Software Carpentry cohorts, he helps
-              communities unlock computational thinking while continuing to explore creative technology.
+              Based in Reservoir, Victoria, Alistair pairs a decade of open science leadership with hands-on expertise in
+              generative AI systems. He helps libraries, universities, and creative studios design responsible AI
+              strategies, orchestrate data-ready pipelines, and prototype agentic tools that deliver measurable impact.
+              From Research Platforms at the University of Melbourne to bespoke client engagements, he meets teams where
+              they are and brings emerging AI capability within reach.
             </p>
             <div class="hero-actions">
-              <a class="button primary" href="https://github.com/alistairwalsh" target="_blank" rel="noopener">Explore open-source work</a>
-              <a class="button ghost" href="#contact">Collaborate</a>
+              <a class="button primary" href="#services">Plan an AI initiative</a>
+              <a class="button ghost" href="#contact">Book a discovery call</a>
             </div>
             <dl class="hero-highlights">
               <div>
-                <dt>Research focus</dt>
-                <dd>Neurofeedback, brain-computer interfaces, data-driven experimentation</dd>
+                <dt>Advisory focus</dt>
+                <dd>Generative AI strategy, agent orchestration, research-grade experimentation</dd>
               </div>
               <div>
                 <dt>Community roles</dt>
@@ -56,7 +59,7 @@
               </div>
               <div>
                 <dt>Toolkit</dt>
-                <dd>Python, R, C++, JavaScript, creative audio &amp; hardware integrations</dd>
+                <dd>Python, R, LangChain, OpenAI &amp; Claude APIs, vector search, data governance playbooks</dd>
               </div>
             </dl>
           </div>
@@ -73,7 +76,7 @@
         <div class="container">
           <div class="section-header">
             <h2 id="impact-title">Impact snapshot</h2>
-            <p>Live metrics pulled from GitHub keep this overview of Alistair's open science footprint up to date.</p>
+            <p>Live metrics pulled from GitHub keep this overview of Alistair's open science and generative AI footprint up to date.</p>
           </div>
           <div class="stats-grid" role="list">
             <article class="stat-card" role="listitem">
@@ -84,7 +87,7 @@
             <article class="stat-card" role="listitem">
               <span class="stat-label">Global collaborators</span>
               <span class="stat-value" data-stat="followers" aria-live="polite">54</span>
-              <p class="stat-description">Researchers and makers following along with neurotech and training initiatives.</p>
+              <p class="stat-description">Researchers, librarians, and product teams following along with neurotech and AI initiatives.</p>
             </article>
             <article class="stat-card" role="listitem">
               <span class="stat-label">Community stars</span>
@@ -103,33 +106,100 @@
       <section class="focus" id="focus" aria-labelledby="focus-title">
         <div class="container">
           <div class="section-header">
-            <h2 id="focus-title">What I'm building</h2>
-            <p>Science, software, and storytelling meet across these core themes.</p>
+            <h2 id="focus-title">Advisory pillars</h2>
+            <p>Strategic guidance tailored to organisations exploring responsible, human-centred AI.</p>
           </div>
           <div class="card-grid">
             <article class="focus-card">
-              <h3>Neurofeedback &amp; BCI research</h3>
-              <p>Designing experiments that close the loop between brain signals and immersive feedback systems. Hands-on with hardware, signal processing pipelines, and rapid prototyping.</p>
+              <h3>Generative AI strategy &amp; governance</h3>
+              <p>Designing roadmaps that connect organisational goals with trustworthy AI practices. Aligning data readiness, risk mitigation, and value realisation.</p>
               <ul>
-                <li>Developed <a href="https://github.com/alistairwalsh/Aquire" target="_blank" rel="noopener">Aquire</a>, a Neuroscan Acquire 4.3 client that keeps EEG research flexible.</li>
-                <li>Built <a href="https://github.com/alistairwalsh/countZero" target="_blank" rel="noopener">countZero</a>, a virtual EEG participant for LabStreamingLayer workflows.</li>
+                <li>Establish AI steering groups, policy frameworks, and evaluation rubrics.</li>
+                <li>Translate research insights into executive-ready roadmaps and investment cases.</li>
               </ul>
             </article>
             <article class="focus-card">
-              <h3>Research platforms &amp; training</h3>
-              <p>Equipping researchers at the University of Melbourne and beyond with the skills to work reproducibly and collaboratively.</p>
+              <h3>Applied prototyping &amp; integrations</h3>
+              <p>Building human-in-the-loop tools with LangChain, open-source agents, and bespoke APIs that slot into existing ecosystems.</p>
               <ul>
-                <li>Rescom ResearchPlatforms@Unimelb facilitator delivering hands-on data intensives.</li>
-                <li>Created workshop materials spanning Python, SQL, data wrangling, and visualization.</li>
+                <li>Rapid prototypes that de-risk AI investments and accelerate buy-in.</li>
+                <li>Reference architectures for knowledge search, workflow automation, and multimodal storytelling.</li>
               </ul>
             </article>
             <article class="focus-card">
-              <h3>Global open science community</h3>
-              <p>Mentoring the next generation of instructors and advocating for inclusive, empowering learning spaces.</p>
+              <h3>AI literacy &amp; enablement</h3>
+              <p>Upskilling cross-functional teams with curricula that blend open science rigor, prompt engineering, and creative exploration.</p>
               <ul>
-                <li>Software Carpentry Instructor Trainer supporting cohorts across Australasia.</li>
-                <li>Regular contributor to Research Bazaar and allied digital skills programs.</li>
+                <li>Facilitated AI capability sprints for researchers, librarians, and creative technologists.</li>
+                <li>Authored reusable lesson kits and playbooks for continuous learning.</li>
               </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="services" id="services" aria-labelledby="services-title">
+        <div class="container">
+          <div class="section-header">
+            <h2 id="services-title">How we can work together</h2>
+            <p>Select the engagement format that fits your team's pace, questions, and experimentation appetite.</p>
+          </div>
+          <div class="service-grid">
+            <article class="service-card">
+              <h3>Strategy intensives</h3>
+              <p>Facilitated workshops that align leadership, surface high-impact use cases, and document next steps in an actionable roadmap.</p>
+              <ul>
+                <li>Pre-engagement discovery interviews</li>
+                <li>Executive-ready opportunity canvas</li>
+                <li>Risk, governance, and policy recommendations</li>
+              </ul>
+              <a class="button ghost" href="#contact">Schedule a workshop</a>
+            </article>
+            <article class="service-card">
+              <h3>Prototype sprints</h3>
+              <p>Time-boxed engagements delivering a working proof-of-concept, integration plan, and metrics framework to evaluate success.</p>
+              <ul>
+                <li>Human-in-the-loop workflow design</li>
+                <li>Agentic tooling with OpenAI, Claude, and open models</li>
+                <li>Documentation for technical handover</li>
+              </ul>
+              <a class="button ghost" href="#contact">Launch a sprint</a>
+            </article>
+            <article class="service-card">
+              <h3>Capability partnerships</h3>
+              <p>Fractional AI leadership that embeds with your team to operationalise playbooks, track outcomes, and cultivate internal champions.</p>
+              <ul>
+                <li>Monthly strategy and measurement sessions</li>
+                <li>Training pathways and enablement collateral</li>
+                <li>Ongoing model, data, and tooling reviews</li>
+              </ul>
+              <a class="button ghost" href="#contact">Explore retainers</a>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="approach" id="approach" aria-labelledby="approach-title">
+        <div class="container">
+          <div class="section-header">
+            <h2 id="approach-title">A collaborative, evidence-led approach</h2>
+            <p>Every engagement balances rapid experimentation with the rigour demanded by research, cultural, and public institutions.</p>
+          </div>
+          <div class="approach-steps">
+            <article class="approach-step">
+              <div class="step-number" aria-hidden="true">01</div>
+              <h3>Map the opportunity</h3>
+              <p>We co-design a value thesis grounded in your data landscape, stakeholder priorities, and governance requirements.</p>
+            </article>
+            <article class="approach-step">
+              <div class="step-number" aria-hidden="true">02</div>
+              <h3>Build &amp; iterate</h3>
+              <p>Rapid prototypes demonstrate what's possible while feedback loops keep humans in control and insights reproducible.</p>
+            </article>
+            <article class="approach-step">
+              <div class="step-number" aria-hidden="true">03</div>
+              <h3>Enable &amp; sustain</h3>
+              <p>Training, documentation, and performance dashboards set your team up to own, scale, and continuously improve the solution.</p>
             </article>
           </div>
         </div>
@@ -139,7 +209,7 @@
         <div class="container">
           <div class="section-header">
             <h2 id="projects-title">Open-source highlights</h2>
-            <p>Recent repositories showcase the blend of research infrastructure, teaching resources, and emerging AI agents.</p>
+            <p>Recent repositories showcase the blend of generative AI agents, research infrastructure, and teaching resources.</p>
           </div>
           <div class="card-grid" id="project-grid" aria-live="polite">
             <article class="project-card placeholder">
@@ -154,7 +224,7 @@
         <div class="container">
           <div class="section-header">
             <h2 id="timeline-title">Milestones</h2>
-            <p>Moments that map the journey from neuroscience student to open science leader.</p>
+            <p>Moments that map the journey from neuroscience student to generative AI consultant and open science leader.</p>
           </div>
           <ol class="timeline-list">
             <li>
@@ -183,6 +253,14 @@
                 <p>Led Software Carpentry workshops at Swinburne University of Technology and the University of Melbourne, expanding the reach of hands-on coding education.</p>
                 <a href="https://github.com/alistairwalsh/2015-05-04-swinpython" target="_blank" rel="noopener">Swinburne workshop</a>
                 <a href="https://github.com/alistairwalsh/2015-05-25-unimelb" target="_blank" rel="noopener">Unimelb workshop</a>
+              </div>
+            </li>
+            <li>
+              <div class="timeline-marker" aria-hidden="true"></div>
+              <div class="timeline-content">
+                <time datetime="2020">2020</time>
+                <h3>Guiding AI literacy for research communities</h3>
+                <p>Designed and delivered remote-first programs helping academics and librarians explore responsible AI, reproducibility, and data stewardship.</p>
               </div>
             </li>
             <li>
@@ -241,7 +319,7 @@
           <div class="callout-text">
             <h2 id="contact-title">Let's collaborate</h2>
             <p>
-              Whether you're exploring neurofeedback, planning a Research Bazaar sprint, or dreaming up a creative technology installation,
+              Whether you're exploring neurofeedback, launching an AI innovation agenda, or dreaming up a creative technology installation,
               reach out to co-design the next experiment.
             </p>
           </div>

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -279,6 +279,8 @@ a.button,
 
 .stats,
 .focus,
+.services,
+.approach,
 .projects,
 .timeline,
 .creative,
@@ -415,6 +417,115 @@ a.button,
 
 .focus-card li::marker {
   color: rgba(108, 240, 194, 0.8);
+}
+
+.services {
+  background: rgba(5, 6, 10, 0.6);
+}
+
+.service-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.7rem;
+}
+
+.service-card {
+  padding: 2.2rem 1.9rem;
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  border: 1px solid rgba(108, 240, 194, 0.22);
+  box-shadow: 0 28px 60px -50px rgba(57, 193, 255, 0.65);
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  transition: transform var(--transition), border-color var(--transition);
+}
+
+.service-card h3 {
+  margin: 0;
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 1.45rem;
+}
+
+.service-card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.service-card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: rgba(248, 249, 251, 0.8);
+  display: grid;
+  gap: 0.55rem;
+}
+
+.service-card li::marker {
+  color: rgba(108, 240, 194, 0.8);
+}
+
+.service-card .button {
+  margin-top: auto;
+  align-self: flex-start;
+}
+
+.service-card:hover,
+.service-card:focus-within {
+  border-color: rgba(108, 240, 194, 0.45);
+  transform: translateY(-4px);
+}
+
+.approach-steps {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.7rem;
+}
+
+.approach-step {
+  padding: 2.1rem 1.8rem;
+  border-radius: var(--radius-md);
+  background: var(--surface-alt);
+  border: 1px solid rgba(108, 240, 194, 0.2);
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  transition: transform var(--transition), border-color var(--transition);
+}
+
+.approach-step::after {
+  content: '';
+  position: absolute;
+  inset: auto -30% -65% 40%;
+  height: 180px;
+  filter: blur(80px);
+  background: radial-gradient(circle, rgba(57, 193, 255, 0.28), transparent 70%);
+  pointer-events: none;
+}
+
+.step-number {
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 1.1rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(108, 240, 194, 0.8);
+}
+
+.approach-step h3 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.approach-step p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.approach-step:hover,
+.approach-step:focus-within {
+  border-color: rgba(108, 240, 194, 0.45);
+  transform: translateY(-3px);
 }
 
 .project-meta {


### PR DESCRIPTION
## Summary
- update the hero, navigation, and milestones to centre the site around generative AI consulting expertise
- add dedicated services and approach sections that outline engagement formats and delivery style
- extend the stylesheet to support the new cards and layout while maintaining the existing visual language

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68dcc2a1974c8322a8b13ec31bf51448