### PR TITLE
Add publications and qualifications sections to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,8 @@
           <a href="#approach">Approach</a>
           <a href="#projects">Projects</a>
           <a href="#timeline">Timeline</a>
+          <a href="#publications">Publications</a>
+          <a href="#qualifications">Qualifications</a>
           <a href="#creative">Creative</a>
           <a href="#contact">Connect</a>
         </nav>
@@ -281,6 +283,101 @@
               </div>
             </li>
           </ol>
+        </div>
+      </section>
+
+      <section class="publications" id="publications" aria-labelledby="publications-title">
+        <div class="container">
+          <div class="section-header">
+            <h2 id="publications-title">Publications &amp; writing</h2>
+            <p>A snapshot of open teaching resources and publications documenting Alistair's research-led practice.</p>
+          </div>
+          <div class="card-grid">
+            <article class="publication-card">
+              <time datetime="2016">2016</time>
+              <h3>New Lesson: Teaching without the jargon</h3>
+              <p>An R Markdown essay distilling workshop experience into learner-first guidance for introducing Python concepts.</p>
+              <ul>
+                <li>Explores practical pedagogy for scientific coding education.</li>
+                <li>Includes reproducible Python snippets and classroom prompts.</li>
+              </ul>
+              <a class="button ghost" href="https://github.com/alistairwalsh/alistairwalsh.github.io/blob/main/new_lesson.Rmd" target="_blank" rel="noopener">Read the essay</a>
+            </article>
+            <article class="publication-card">
+              <time datetime="2016">2016</time>
+              <h3>SQL Week at NeuralCode</h3>
+              <p>A long-form blog post introducing database fundamentals for researchers transitioning from spreadsheets to SQL.</p>
+              <ul>
+                <li>Demonstrates SQLite commands and query patterns.</li>
+                <li>Highlights data management workflows for experiments.</li>
+              </ul>
+              <a class="button ghost" href="https://github.com/alistairwalsh/alistairwalsh.github.io/blob/main/blog.md" target="_blank" rel="noopener">View the guide</a>
+            </article>
+            <article class="publication-card">
+              <time datetime="2015">2015</time>
+              <h3>Software Carpentry: Swinburne Python workshop</h3>
+              <p>Comprehensive lesson materials powering the Swinburne University of Technology Python bootcamp.</p>
+              <ul>
+                <li>Hands-on notebooks, exercises, and instructor notes.</li>
+                <li>Supports research computing skills across campuses.</li>
+              </ul>
+              <a class="button ghost" href="https://github.com/alistairwalsh/2015-05-04-swinpython" target="_blank" rel="noopener">Browse the materials</a>
+            </article>
+            <article class="publication-card">
+              <time datetime="2013">2013</time>
+              <h3>Aquire: Streaming EEG research data</h3>
+              <p>Python client enabling Neuroscan Acquire 4.3 data streaming for neurofeedback experimentation.</p>
+              <ul>
+                <li>Bridges lab hardware with flexible analysis workflows.</li>
+                <li>Published under an open-source license for reuse.</li>
+              </ul>
+              <a class="button ghost" href="https://github.com/alistairwalsh/Aquire" target="_blank" rel="noopener">Explore the repository</a>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="qualifications" id="qualifications" aria-labelledby="qualifications-title">
+        <div class="container">
+          <div class="section-header">
+            <h2 id="qualifications-title">Qualifications &amp; accreditation</h2>
+            <p>Formal study and professional credentials underpinning responsible generative AI and neurotechnology engagements.</p>
+          </div>
+          <div class="credentials-grid">
+            <article class="credential-card">
+              <header>
+                <span class="credential-label">Academic degree</span>
+                <h3>BSc (Honours) Cognitive Neuroscience</h3>
+              </header>
+              <p>Swinburne University of Technology</p>
+              <ul>
+                <li>Honours research focused on neurofeedback and brain-computer interfaces.</li>
+                <li>Combined human factors, data analysis, and experimental design.</li>
+              </ul>
+            </article>
+            <article class="credential-card">
+              <header>
+                <span class="credential-label">Professional certification</span>
+                <h3>Software Carpentry Instructor Trainer</h3>
+              </header>
+              <p>The Carpentries</p>
+              <ul>
+                <li>Certified to mentor and assess new instructors globally.</li>
+                <li>Delivers evidence-based pedagogy for research computing.</li>
+              </ul>
+            </article>
+            <article class="credential-card">
+              <header>
+                <span class="credential-label">Leadership role</span>
+                <h3>Research Platforms Associate, AI &amp; data programs</h3>
+              </header>
+              <p>University of Melbourne</p>
+              <ul>
+                <li>Co-designed the Data Fluency program supporting 10k+ researchers.</li>
+                <li>Leads ethical AI capability building across library partnerships.</li>
+              </ul>
+            </article>
+          </div>
         </div>
       </section>
 

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -283,6 +283,8 @@ a.button,
 .approach,
 .projects,
 .timeline,
+.publications,
+.qualifications,
 .creative,
 .toolbox,
 .callout {
@@ -343,7 +345,9 @@ a.button,
 
 .focus-card,
 .project-card,
-.tool-card {
+.tool-card,
+.publication-card,
+.credential-card {
   padding: 2rem 1.75rem;
   border-radius: var(--radius-md);
   background: var(--surface-alt);
@@ -387,14 +391,20 @@ a.button,
 .project-card:hover,
 .project-card:focus-within,
 .tool-card:hover,
-.tool-card:focus-within {
+.tool-card:focus-within,
+.publication-card:hover,
+.publication-card:focus-within,
+.credential-card:hover,
+.credential-card:focus-within {
   transform: translateY(-4px);
   border-color: rgba(108, 240, 194, 0.5);
 }
 
 .focus-card h3,
 .project-card h3,
-.tool-card h3 {
+.tool-card h3,
+.publication-card h3,
+.credential-card h3 {
   font-family: 'Space Grotesk', sans-serif;
   margin: 0;
   font-size: 1.4rem;
@@ -402,7 +412,9 @@ a.button,
 
 .focus-card p,
 .project-card p,
-.tool-card p {
+.tool-card p,
+.publication-card p,
+.credential-card p {
   margin: 0;
   color: var(--muted);
 }
@@ -417,6 +429,46 @@ a.button,
 
 .focus-card li::marker {
   color: rgba(108, 240, 194, 0.8);
+}
+
+.publication-card time {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: rgba(108, 240, 194, 0.75);
+}
+
+.publication-card ul,
+.credential-card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: rgba(248, 249, 251, 0.75);
+  display: grid;
+  gap: 0.55rem;
+}
+
+.publication-card li::marker,
+.credential-card li::marker {
+  color: rgba(108, 240, 194, 0.65);
+}
+
+.credentials-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.7rem;
+}
+
+.credential-card header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.credential-label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: rgba(108, 240, 194, 0.75);
 }
 
 .services {


### PR DESCRIPTION
## Summary
- add homepage navigation entries for new publications and qualifications sections
- publish curated publication cards and credential highlights with descriptive copy and outbound links
- extend the shared card styling to support publication and credential layouts

## Testing
- Manual QA - not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68dd1c2cb9d0832296967fef28eb52c1